### PR TITLE
 Improve attr regex to migrate transform types

### DIFF
--- a/transforms/em-to-ed/README.md
+++ b/transforms/em-to-ed/README.md
@@ -17,6 +17,7 @@ npx github:patocallaghan/em-to-ed-codemod em-to-ed path/of/files/ or/some**/*glo
 * [model-belongs-to__keys-match](#model-belongs-to__keys-match)
 * [model-has-many__keys-dont-match](#model-has-many__keys-dont-match)
 * [model-has-many__keys-match](#model-has-many__keys-match)
+* [transform-types](#transform-types)
 <!--FIXTURES_TOC_END-->
 
 <!--FIXTURES_CONTENT_START-->
@@ -243,6 +244,40 @@ import Tag from 'embercom/models/tag';
 
 export default DS.Model.extend({
   tags: DS.attr('ember-model-has-many', { modelClass: Tag, embedded: true }),
+});
+
+```
+---
+<a id="transform-types">**transform-types**</a>
+
+**Input** (<small>[transform-types.input.js](transforms/em-to-ed/__testfixtures__/transform-types.input.js)</small>):
+```js
+import IntercomModel from 'embercom/models/types/intercom-model';
+import { attr } from 'ember-model';
+import JsonType from 'embercom/models/types/json';
+
+export default IntercomModel.extend({
+  emptyTransform: attr(),
+  someJson: attr(JsonType),
+  someArray: attr(Array),
+  someBoolean: attr(Boolean),
+  someNumber: attr(Number),
+  someString: attr(String),
+});
+
+```
+
+**Output** (<small>[transform-types.output.js](transforms/em-to-ed/__testfixtures__/transform-types.output.js)</small>):
+```js
+import DS from 'ember-data';
+
+export default DS.Model.extend({
+  emptyTransform: DS.attr(),
+  someJson: DS.attr(),
+  someArray: DS.attr('array'),
+  someBoolean: DS.attr('boolean'),
+  someNumber: DS.attr('number'),
+  someString: DS.attr('string'),
 });
 
 ```

--- a/transforms/em-to-ed/__testfixtures__/transform-types.input.js
+++ b/transforms/em-to-ed/__testfixtures__/transform-types.input.js
@@ -3,8 +3,10 @@ import { attr } from 'ember-model';
 import JsonType from 'embercom/models/types/json';
 
 export default IntercomModel.extend({
+  emptyTransform: attr(),
   someJson: attr(JsonType),
   someArray: attr(Array),
   someBoolean: attr(Boolean),
   someNumber: attr(Number),
+  someString: attr(String),
 });

--- a/transforms/em-to-ed/__testfixtures__/transform-types.output.js
+++ b/transforms/em-to-ed/__testfixtures__/transform-types.output.js
@@ -1,8 +1,10 @@
 import DS from 'ember-data';
 
 export default DS.Model.extend({
+  emptyTransform: DS.attr(),
   someJson: DS.attr(),
   someArray: DS.attr('array'),
   someBoolean: DS.attr('boolean'),
   someNumber: DS.attr('number'),
+  someString: DS.attr('string'),
 });

--- a/transforms/em-to-ed/util/attr-transform.js
+++ b/transforms/em-to-ed/util/attr-transform.js
@@ -1,0 +1,42 @@
+const FORMATTING = require('./formatting');
+
+function migrateAttrParams(j, params) {
+  let newTypes = {
+    String: 'string',
+    Boolean: 'boolean',
+    Number: 'number',
+    Array: 'array',
+    JsonType: '',
+  };
+  if (!params.length) {
+    return params;
+  }
+  if (params[0].type !== 'Identifier') {
+    return params;
+  }
+  let newType = newTypes[params[0].name];
+  params.shift();
+
+  if (newType) {
+    params.unshift(j.literal(newType));
+  }
+
+  return params;
+}
+
+function attrTransform(j, source) {
+  return j(source)
+    .find(j.CallExpression, {
+      callee: {
+        name: 'attr',
+      },
+    })
+    .forEach(path => {
+      path.replace(
+        j.callExpression(j.identifier('DS.attr'), migrateAttrParams(j, path.value.arguments)),
+      );
+    })
+    .toSource(FORMATTING);
+}
+
+module.exports = attrTransform;

--- a/transforms/em-to-ed/util/closest-ancestor-of-type.js
+++ b/transforms/em-to-ed/util/closest-ancestor-of-type.js
@@ -1,0 +1,9 @@
+function closestAncestorOfType(startPath, typeRegex) {
+  let current = startPath.parentPath;
+  while (current.parentPath && !typeRegex.test(current.value.type)) {
+    current = current.parentPath;
+  }
+  return current || null;
+}
+
+module.exports = closestAncestorOfType;


### PR DESCRIPTION
```js
//BEFORE
import IntercomModel from 'embercom/models/types/intercom-model';
import { attr } from 'ember-model';
import JsonType from 'embercom/models/types/json';

export default IntercomModel.extend({
  someJson: attr(JsonType),
  someArray: attr(Array),
  someBoolean: attr(Boolean),
  someNumber: attr(Number),
  someString: attr(String),
});

//AFTER
Import DS from 'ember-data';

export default DS.Model.extend({
  someJson: DS.attr(),
  someArray: DS.attr('array'),
  someBoolean: DS.attr('boolean'),
  someNumber: DS.attr('number'),
  someString: DS.attr('string'),
});
```