### PR TITLE
Add code migration hints for custom Ember Model configuration

### DIFF
--- a/transforms/em-to-ed/README.md
+++ b/transforms/em-to-ed/README.md
@@ -11,6 +11,7 @@ npx github:patocallaghan/em-to-ed-codemod em-to-ed path/of/files/ or/some**/*glo
 
 <!--FIXTURES_TOC_START-->
 * [default-values](#default-values)
+* [ember-model-configuration](#ember-model-configuration)
 * [get-ember-data-store](#get-ember-data-store)
 * [get-ember-data-store__reopen-class](#get-ember-data-store__reopen-class)
 * [get-ember-data-store__reopen-class__other-usage](#get-ember-data-store__reopen-class__other-usage)
@@ -54,6 +55,51 @@ export default DS.Model.extend({
   avatar_emoji: DS.attr('string', { defaultValue: DEFAULT_EMOJI }),
   someArray: DS.attr('array', { defaultValue: () => [] }),
   someJson: DS.attr({ defaultValue: () => ({}) }),
+});
+
+```
+---
+<a id="ember-model-configuration">**ember-model-configuration**</a>
+
+**Input** (<small>[ember-model-configuration.input.js](transforms/em-to-ed/__testfixtures__/ember-model-configuration.input.js)</small>):
+```js
+import IntercomModel from 'embercom/models/types/intercom-model';
+
+export default IntercomModel.extend({
+  someValue: attr(),
+}).reopenClass({
+  adapter: ConversationPartRESTAdapter.create(),
+  collectionKey: 'conversation_parts',
+  primaryKey: 'id',
+  primaryKey: 'app_id',
+  rootKey: '',
+  url: '/ember/conversation_parts',
+  urlSuffix: '.json',
+});
+
+```
+
+**Output** (<small>[ember-model-configuration.output.js](transforms/em-to-ed/__testfixtures__/ember-model-configuration.output.js)</small>):
+```js
+import DS from 'ember-data';
+
+export default DS.Model.extend({
+  someValue: DS.attr(),
+}).reopenClass({
+  // CODE MIGRATION HINT: This model had a custom `adapter` defined so it may contain functionality which does not come out of the box in Ember Data. Visit the docs at https://github.com/intercom/embercom/wiki/Converting-a-model-from-ember-model-to-ember-data#migrating-custom-ember-model-configuration-to-ember-data to see how to address this issue.
+  adapter: ConversationPartRESTAdapter.create(),
+
+  // CODE MIGRATION HINT: This model had a `collectionKey` defined so its payload will not automatically map to Ember Data. Visit the docs at https://github.com/intercom/embercom/wiki/Converting-a-model-from-ember-model-to-ember-data#migrating-custom-ember-model-configuration-to-ember-data to see how to address this issue.
+  collectionKey: 'conversation_parts',
+
+  // CODE MIGRATION HINT: This model had a custom `primaryKey` defined so you may need configure this in an Ember Data serializer. Visit the docs at https://github.com/intercom/embercom/wiki/Converting-a-model-from-ember-model-to-ember-data#migrating-custom-ember-model-configuration-to-ember-data to see how to address this issue.
+  primaryKey: 'app_id',
+
+  // CODE MIGRATION HINT: This model had a custom `url` defined so its URL may not automatically map to Ember Data's. Visit the docs at https://github.com/intercom/embercom/wiki/Converting-a-model-from-ember-model-to-ember-data#migrating-custom-ember-model-configuration-to-ember-data to see how to address this issue.
+  url: '/ember/conversation_parts',
+
+  // CODE MIGRATION HINT: This model had a custom `urlSuffix` defined so you may need to configure this in an Ember Data serializer. Visit the docs at https://github.com/intercom/embercom/wiki/Converting-a-model-from-ember-model-to-ember-data#migrating-custom-ember-model-configuration-to-ember-data to see how to address this issue.
+  urlSuffix: '.json',
 });
 
 ```

--- a/transforms/em-to-ed/__testfixtures__/ember-model-configuration.input.js
+++ b/transforms/em-to-ed/__testfixtures__/ember-model-configuration.input.js
@@ -1,0 +1,13 @@
+import IntercomModel from 'embercom/models/types/intercom-model';
+
+export default IntercomModel.extend({
+  someValue: attr(),
+}).reopenClass({
+  adapter: ConversationPartRESTAdapter.create(),
+  collectionKey: 'conversation_parts',
+  primaryKey: 'id',
+  primaryKey: 'app_id',
+  rootKey: '',
+  url: '/ember/conversation_parts',
+  urlSuffix: '.json',
+});

--- a/transforms/em-to-ed/__testfixtures__/ember-model-configuration.output.js
+++ b/transforms/em-to-ed/__testfixtures__/ember-model-configuration.output.js
@@ -1,0 +1,20 @@
+import DS from 'ember-data';
+
+export default DS.Model.extend({
+  someValue: DS.attr(),
+}).reopenClass({
+  // CODE MIGRATION HINT: This model had a custom `adapter` defined so it may contain functionality which does not come out of the box in Ember Data. Visit the docs at https://github.com/intercom/embercom/wiki/Converting-a-model-from-ember-model-to-ember-data#migrating-custom-ember-model-configuration-to-ember-data to see how to address this issue.
+  adapter: ConversationPartRESTAdapter.create(),
+
+  // CODE MIGRATION HINT: This model had a `collectionKey` defined so its payload will not automatically map to Ember Data. Visit the docs at https://github.com/intercom/embercom/wiki/Converting-a-model-from-ember-model-to-ember-data#migrating-custom-ember-model-configuration-to-ember-data to see how to address this issue.
+  collectionKey: 'conversation_parts',
+
+  // CODE MIGRATION HINT: This model had a custom `primaryKey` defined so you may need configure this in an Ember Data serializer. Visit the docs at https://github.com/intercom/embercom/wiki/Converting-a-model-from-ember-model-to-ember-data#migrating-custom-ember-model-configuration-to-ember-data to see how to address this issue.
+  primaryKey: 'app_id',
+
+  // CODE MIGRATION HINT: This model had a custom `url` defined so its URL may not automatically map to Ember Data's. Visit the docs at https://github.com/intercom/embercom/wiki/Converting-a-model-from-ember-model-to-ember-data#migrating-custom-ember-model-configuration-to-ember-data to see how to address this issue.
+  url: '/ember/conversation_parts',
+
+  // CODE MIGRATION HINT: This model had a custom `urlSuffix` defined so you may need to configure this in an Ember Data serializer. Visit the docs at https://github.com/intercom/embercom/wiki/Converting-a-model-from-ember-model-to-ember-data#migrating-custom-ember-model-configuration-to-ember-data to see how to address this issue.
+  urlSuffix: '.json',
+});

--- a/transforms/em-to-ed/index.js
+++ b/transforms/em-to-ed/index.js
@@ -2,6 +2,7 @@ const { getParser } = require('codemod-cli').jscodeshift;
 const belongsToTransform = require('./util/belongs-to-transform');
 const hasManyTransform = require('./util/has-many-transform');
 const attrTransform = require('./util/attr-transform');
+const annotateEmberModelConfiguration = require('./util/annotate-ember-model-configuration');
 const closestAncestorOfType = require('./util/closest-ancestor-of-type');
 const getAncestorsOfType = require('./util/get-ancestors-of-type');
 const removeImportSpecifier = require('./util/remove-import-specifier');
@@ -160,5 +161,6 @@ module.exports = function transformer(file, api) {
   source = belongsToTransform(j, source);
   source = removeJsonTypeImport(j, source);
   source = migrateGetEmberDataStore(j, source);
+  source = annotateEmberModelConfiguration(j, source);
   return source;
 };

--- a/transforms/em-to-ed/util/annotate-ember-model-configuration.js
+++ b/transforms/em-to-ed/util/annotate-ember-model-configuration.js
@@ -1,0 +1,62 @@
+const FORMATTING = require('./formatting');
+
+const COMMENT_TEXT = {
+  adapter:
+    ' CODE MIGRATION HINT: This model had a custom `adapter` defined so it may contain functionality which does not come out of the box in Ember Data. Visit the docs at https://github.com/intercom/embercom/wiki/Converting-a-model-from-ember-model-to-ember-data#migrating-custom-ember-model-configuration-to-ember-data to see how to address this issue.',
+  collectionKey:
+    ' CODE MIGRATION HINT: This model had a `collectionKey` defined so its payload will not automatically map to Ember Data. Visit the docs at https://github.com/intercom/embercom/wiki/Converting-a-model-from-ember-model-to-ember-data#migrating-custom-ember-model-configuration-to-ember-data to see how to address this issue.',
+  primaryKey:
+    ' CODE MIGRATION HINT: This model had a custom `primaryKey` defined so you may need configure this in an Ember Data serializer. Visit the docs at https://github.com/intercom/embercom/wiki/Converting-a-model-from-ember-model-to-ember-data#migrating-custom-ember-model-configuration-to-ember-data to see how to address this issue.',
+  url:
+    " CODE MIGRATION HINT: This model had a custom `url` defined so its URL may not automatically map to Ember Data's. Visit the docs at https://github.com/intercom/embercom/wiki/Converting-a-model-from-ember-model-to-ember-data#migrating-custom-ember-model-configuration-to-ember-data to see how to address this issue.",
+  urlSuffix:
+    ' CODE MIGRATION HINT: This model had a custom `urlSuffix` defined so you may need to configure this in an Ember Data serializer. Visit the docs at https://github.com/intercom/embercom/wiki/Converting-a-model-from-ember-model-to-ember-data#migrating-custom-ember-model-configuration-to-ember-data to see how to address this issue.',
+};
+
+const EMBER_MODEL_CONFIGURATION_KEYS = [
+  'adapter',
+  'collectionKey',
+  'primaryKey',
+  'url',
+  'urlSuffix',
+  'rootKey',
+];
+
+function addComment(j, path, text) {
+  let comment = j.commentLine(text, true, false);
+  path.comments = path.comments || [];
+  if (!path.comments.find(comment => comment.value.includes(text))) {
+    path.comments.push(comment);
+  }
+}
+
+function annotateEmberModelConfiguration(j, source) {
+  return j(source)
+    .find(j.CallExpression, {
+      callee: {
+        property: {
+          name: 'reopenClass',
+        },
+      },
+    })
+    .forEach(path => {
+      let obj = path.value.arguments.find(n => n.type === 'ObjectExpression');
+      obj.properties
+        .filter(prop => EMBER_MODEL_CONFIGURATION_KEYS.includes(prop.key.name))
+        .forEach(prop => {
+          // Remove empty configuration keys or `primaryKey: 'id'`
+          if (
+            (prop.key.name === 'primaryKey' && prop.value.value === 'id') ||
+            (prop.value.type.includes('Literal') && !prop.value.value)
+          ) {
+            let propertyIndex = obj.properties.findIndex(p => p.value.value === prop.value.value);
+            obj.properties.splice(propertyIndex, 1);
+          } else {
+            addComment(j, prop, COMMENT_TEXT[prop.key.name]);
+          }
+        });
+    })
+    .toSource(FORMATTING);
+}
+
+module.exports = annotateEmberModelConfiguration;


### PR DESCRIPTION
Where we can't automatically migrate Ember Model configuration settings we'll instead leave a comment hint which will bring the engineer's attention.

Properties we'll add a comment on are:

```
adapter
collectionKey
primaryKey
rootKey
url
urlSuffix
```

If the configuration values are empty we'll nuke them, e.g. `collectionKey: ''` or in the case where a `primaryKey` is set to `id` as this is default behaviour in Ember Data.